### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm run develop"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/d8194fb5-bc0e-4495-8f3c-6b9da16995ae/deploy-status)](https://app.netlify.com/sites/reverent-lovelace-205163/deploys)
 
+[![Run on Repl.it](https://repl.it/badge/github/romitkarmakar/digitalfortress_frontend)](https://repl.it/github/romitkarmakar/digitalfortress_frontend)
+
 This is a quiz competition developed by GLUG for testing the students skills in Linux Terminal Commands and common computer science related questions.
 
 ## Installation


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@romitkarmakar/digitalfortressfrontend).